### PR TITLE
SDL_sound: rename to SDL2_sound

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,12 +1,12 @@
-lib_LTLIBRARIES = libSDL_sound.la
+lib_LTLIBRARIES = libSDL2_sound.la
 
 SUBDIRS = decoders .
 
-libSDL_soundincludedir = $(includedir)/SDL2
-libSDL_soundinclude_HEADERS =	\
+libSDL2_soundincludedir = $(includedir)/SDL2
+libSDL2_soundinclude_HEADERS =	\
 	SDL_sound.h
 
-libSDL_sound_la_SOURCES =	\
+libSDL2_sound_la_SOURCES =	\
 	SDL_sound.c	\
 	SDL_sound_internal.h	\
     audio_convert.c   \
@@ -25,11 +25,11 @@ else
 MPG123_LIB =
 endif
 
-libSDL_sound_la_LDFLAGS = 		\
+libSDL2_sound_la_LDFLAGS = 		\
 	-release $(LT_RELEASE)	\
 	-version-info $(LT_CURRENT):$(LT_REVISION):$(LT_AGE) \
 	-no-undefined
-libSDL_sound_la_LIBADD =	\
+libSDL2_sound_la_LIBADD =	\
 	decoders/libdecoders.la	\
 	$(TIMIDITY_LIB) $(MPG123_LIB)
 
@@ -51,4 +51,4 @@ dist-hook:
 	rm -rf `find $(distdir) -type d -name ".svn"`
 
 pkgconfigdir = $(libdir)/pkgconfig
-pkgconfig_DATA = SDL_sound.pc
+pkgconfig_DATA = SDL2_sound.pc

--- a/SDL2_sound.pc.in
+++ b/SDL2_sound.pc.in
@@ -3,9 +3,9 @@ exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
 
-Name: SDL_sound
+Name: SDL2_sound
 Description: audio decoding library for Simple DirectMedia Layer
 Version: @VERSION@
 Requires: sdl2 >= @SDL_VERSION@
-Libs: -L${libdir} -lSDL_sound
+Libs: -L${libdir} -lSDL2_sound
 Cflags: -I${includedir}/SDL2

--- a/configure.in
+++ b/configure.in
@@ -44,7 +44,7 @@ AC_CANONICAL_TARGET
 
 dnl Setup for automake
 AM_CONFIG_HEADER(config.h)
-AM_INIT_AUTOMAKE(SDL_sound, $VERSION)
+AM_INIT_AUTOMAKE(SDL2_sound, $VERSION)
 
 
 dnl ---------------------------------------------------------------------
@@ -340,5 +340,5 @@ decoders/Makefile
 decoders/timidity/Makefile
 decoders/libmpg123/Makefile
 playsound/Makefile
-SDL_sound.pc
+SDL2_sound.pc
 ])

--- a/playsound/Makefile.am
+++ b/playsound/Makefile.am
@@ -12,9 +12,9 @@ PHYSFS_LIBS =
 endif
 
 playsound_CFLAGS = $(PHYSFS_CFLG)
-playsound_LDADD = ../libSDL_sound.la $(PHYSFS_LIBS)
+playsound_LDADD = ../libSDL2_sound.la $(PHYSFS_LIBS)
 playsound_SOURCES = playsound.c physfsrwops.c physfsrwops.h
 
-playsound_simple_LDADD = ../libSDL_sound.la
+playsound_simple_LDADD = ../libSDL2_sound.la
 playsound_simple_SOURCES = playsound_simple.c
 


### PR DESCRIPTION
Renamed so it can be installed alongside vanilla SDL_sound without file
conflicts

Signed-off-by: Marty Plummer <ntzrmtthihu777@gmail.com>